### PR TITLE
Continous Integration Travis & AppVeyor

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,36 +1,34 @@
 #/bin/bash
 
-travis_before_install() 
-{
-	cd ..
-	if [ "$TARGET_OS" = "Linux" ]; then
-		sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
-		sudo apt-get update -qq;
-		sudo apt-get install -qq ;
-		sudo apt-get install -qq libsdl2-dev gcc-5 g++-5 cmake;
-	elif [ "$TARGET_OS" = "OSX" ]; then
-		brew update
-		brew install sdl2
-	fi;
 
+travis_before_install() {
+  cd ..
+  if [ "$TARGET_OS" = "Linux" ]; then
+    sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+    sudo apt-get update -qq;
+    sudo apt-get install -qq ;
+    sudo apt-get install -qq libsdl2-dev gcc-5 g++-5 cmake;
+  elif [ "$TARGET_OS" = "OSX" ]; then
+    brew update
+    brew install sdl2
+  fi;
 }
 
-travis_script()
-{
 
-	mkdir build
-	pushd build
-	
-	if [ "$TARGET_OS" = "Linux" ]; then
-		if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
-		cmake .. -G"$BUILD_TYPE" -DCMAKE_BUILD_TYPE=Release;
-		cmake --build .
-	elif [ "$TARGET_OS" = "OSX" ]; then
-		cmake .. -G"$BUILD_TYPE"
-		cmake --build . --config Release
-	fi;
+travis_script() {
+  mkdir build
+  pushd build
 
-	popd
+  if [ "$TARGET_OS" = "Linux" ]; then
+    if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+    cmake .. -G"$BUILD_TYPE" -DCMAKE_BUILD_TYPE=Release;
+    cmake --build .
+  elif [ "$TARGET_OS" = "OSX" ]; then
+    cmake .. -G"$BUILD_TYPE"
+    cmake --build . --config Release
+  fi;
+
+  popd
 }
 
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,40 @@
+#/bin/bash
+
+travis_before_install() 
+{
+	cd ..
+	if [ "$TARGET_OS" = "Linux" ]; then
+		sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+		sudo apt-get update -qq;
+		sudo apt-get install -qq ;
+		sudo apt-get install -qq libsdl2-dev gcc-5 g++-5 cmake;
+	elif [ "$TARGET_OS" = "OSX" ]; then
+		brew update
+		brew install sdl2
+	fi;
+
+}
+
+travis_script()
+{
+
+	mkdir build
+	pushd build
+	
+	if [ "$TARGET_OS" = "Linux" ]; then
+		if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+		cmake .. -G"$BUILD_TYPE" -DCMAKE_BUILD_TYPE=Release;
+		cmake --build .
+	elif [ "$TARGET_OS" = "OSX" ]; then
+		cmake .. -G"$BUILD_TYPE"
+		cmake --build . --config Release
+	fi;
+
+	popd
+}
+
+
+set -e
+set -x
+
+$1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env:
+        - BUILD_TYPE="Unix Makefiles"
+        - TARGET_OS=Linux
+      sudo: require
+    - os: osx
+      osx_image: xcode8.3
+      env:
+        - BUILD_TYPE=Xcode
+        - TARGET_OS=OSX
+
+before_install:
+  - bash .travis.sh travis_before_install
+  
+script:
+  - bash .travis.sh travis_script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 project(psxact)
 
 set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/modules
-	${CMAKE_MODULE_PATH}
+    ${CMAKE_CURRENT_SOURCE_DIR}/modules
+    ${CMAKE_MODULE_PATH}
 )
 
 set(SDL2_PATH "" CACHE INTERNAL "Fill in path to the SDL2 (Win32)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.0)
 project(psxact)
 
+set(CMAKE_MODULE_PATH
+	${CMAKE_CURRENT_SOURCE_DIR}/modules
+	${CMAKE_MODULE_PATH}
+)
+
+set(SDL2_PATH "" CACHE INTERNAL "Fill in path to the SDL2 (Win32)")
 find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIR})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ set(SDL2_PATH "" CACHE INTERNAL "Fill in path to the SDL2 (Win32)")
 find_package(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIR})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(SOURCE_FILES
     src/cdrom/cdrom_core.cpp

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PSXACT
 
+[![Build Status](https://travis-ci.org/adam-becker/psxact.svg?branch=develop)](https://travis-ci.org/adam-becker/psxact)
+[![Build status](https://ci.appveyor.com/api/projects/status/drk4b45g4pyij3ij/branch/develop?svg=true)](https://ci.appveyor.com/project/adam-becker/psxact/branch/develop)
+
 This project aims to emulate the PlayStation&trade; 1 console in an accurate
 fashion. No hacks or proprietary software will be used to accomplish this goal.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: '{build}'
+image: Visual Studio 2017
+environment:
+  BUILD_TYPE: Visual Studio 15 2017 Win64
+  matrix:
+  - CONFIG_TYPE: Release
+build_script:
+- cmd: >-
+    set REPO_COMMIT_SHORT=%APPVEYOR_REPO_COMMIT:~0,8%
+
+    appveyor SetVariable -Name REPO_COMMIT_SHORT -Value %REPO_COMMIT_SHORT%
+
+    appveyor DownloadFile https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip
+
+    7z x SDL2-devel-2.0.5-VC.zip
+
+    mkdir build
+
+    cd build
+
+    cmake .. -G"%BUILD_TYPE%" -DSDL2_PATH="C:\\projects\\psxact\\SDL2-2.0.5"
+
+    cmake --build . --config %CONFIG_TYPE%
+
+    mkdir ..\%REPO_COMMIT_SHORT%
+
+    move Release\*.exe ..\%REPO_COMMIT_SHORT%\
+
+artifacts:
+- path: $(REPO_COMMIT_SHORT)\*.exe
+  name: Binaries

--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -1,8 +1,173 @@
-include(FindPackageHandleStandardArgs)
 
-set(SDL2_LIBRARY "" CACHE STRING "Fill in path to the SDL2.lib file")
-set(SDL2_INCLUDE_DIR "" CACHE INTERNAL "Fill in path to the SDL2/include folder")
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
 
-find_package_handle_standard_args(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
 
-include_directories(${SDL2_INCLUDE_DIR})
+# message("<FindSDL2.cmake>")
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+	${SDL2_PATH}
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(PATH_SUFFIXES lib64 lib/x64 lib)
+else()
+	set(PATH_SUFFIXES lib/x86 lib)
+endif()
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES ${PATH_SUFFIXES}
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES ${PATH_SUFFIXES}
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+# message("</FindSDL2.cmake>")
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)


### PR DESCRIPTION
~~ok, please don't consider merging this yet, I still need to cleanup the commit and merge some of them.
I'm only pushing this to see if Travis would build correct on your end.~~

and also, I'd like your opinion on the last commit. `97ccde4` just read the comment in it.
also, i did not really have a look at all at "library" aspect of the emu and if that's how it should be broken down so thats not likely to be part of this PR.

Edit: also, sorry for the singular PR, i'd push the cleanup and travis separately, but in this case, ~~they need to be done together anyway.~~ it's a small cleanup.

Edit2: ok this PR is ready, I hope now you see what I meant that you can use the same `FindSDL2.cmake` for all platforms.

if you have any questions, feel free to ask. and be free about being critical about any of the changes.

something worth mentioning, Both CI supports artefacts (binaries) deployment, however Appveyor can also host them [itself](https://ci.appveyor.com/project/adam-becker/psxact/build/3/artifacts), for Travis & even AppVeyor deployment you'd need to sign up to a 3rd party sites as mentioned [here](https://www.appveyor.com/docs/deployment/) but this early on, I wouldnt imagine this would really be a concern.